### PR TITLE
ruby.wasmダウンロード処理の改善

### DIFF
--- a/.github/workflows/ruby-nightly.yml
+++ b/.github/workflows/ruby-nightly.yml
@@ -42,21 +42,15 @@ jobs:
           npm update
           bundle update
           (cd src && bundle update)
-          bundle exec rake bormashino:download
 
-      - name: get latest ruby.wasm
+      - name: get latest ruby.wasm and test
         run: |
           cd test-app
           rm -rf head-wasm32-unknown-wasi-full-js
           wget https://github.com/maiha/xq.cr/releases/download/v0.3.0/xq
           chmod u+x xq
-          export RUBY_NIGHTLY=$(curl https://github.com/ruby/ruby.wasm/releases.atom | ./xq .title | tee | head -2 | tail -1 | sed -r 's/^.+>(.+?)<.+$/\1/g')
-          echo $RUBY_NIGHTLY
-          curl -L https://github.com/ruby/ruby.wasm/releases/download/${RUBY_NIGHTLY}/ruby-head-wasm32-unknown-wasi-full-js.tar.gz | tar xz
-
-      - name: test
-        run: |
-          cd test-app
+          export RELEASE_DATE=$(curl https://github.com/ruby/ruby.wasm/releases.atom | ./xq .title | tee | head -2 | tail -1 | sed -r 's/^.+>(.+?)<.+$/\1/g')
+          echo $RELEASE_DATE
           bundle exec rake
           nohup npm run dev &
           sleep 15

--- a/.github/workflows/test-app-integration.yml
+++ b/.github/workflows/test-app-integration.yml
@@ -40,7 +40,6 @@ jobs:
           npm update
           bundle update
           (cd src && bundle update)
-          bundle exec rake bormashino:download
           bundle exec rake
 
       - name: test
@@ -80,7 +79,6 @@ jobs:
           cd test-app
           bundle update
           (cd src && bundle update)
-          bundle exec rake bormashino:download
 
       - name: test
         run: |

--- a/gem/lib/bormashino/tasks/bormashino.rake
+++ b/gem/lib/bormashino/tasks/bormashino.rake
@@ -3,7 +3,7 @@ require 'uri'
 require 'os'
 require 'digest/md5'
 
-RELEASE_DATE = '2022-05-30-a'.freeze
+RELEASE_DATE = ENV['RELEASE_DATE'] || '2022-05-30-a'.freeze
 RUBY_RELEASE = "https://github.com/ruby/ruby.wasm/releases/download/#{RELEASE_DATE}/ruby-head-wasm32-unknown-wasi-full-js.tar.gz".freeze
 
 WASI_VFS_RELEASE = 'https://github.com/kateinoigakukun/wasi-vfs/releases/download/v0.1.1/wasi-vfs-cli-x86_64-unknown-linux-gnu.zip'.freeze

--- a/gem/lib/bormashino/tasks/bormashino.rake
+++ b/gem/lib/bormashino/tasks/bormashino.rake
@@ -3,48 +3,69 @@ require 'uri'
 require 'os'
 require 'digest/md5'
 
-RUBY_RELEASE = 'https://github.com/ruby/ruby.wasm/releases/download/2022-05-30-a/ruby-head-wasm32-unknown-wasi-full-js.tar.gz'.freeze
+RELEASE_DATE = '2022-05-30-a'.freeze
+RUBY_RELEASE = "https://github.com/ruby/ruby.wasm/releases/download/#{RELEASE_DATE}/ruby-head-wasm32-unknown-wasi-full-js.tar.gz".freeze
+
 WASI_VFS_RELEASE = 'https://github.com/kateinoigakukun/wasi-vfs/releases/download/v0.1.1/wasi-vfs-cli-x86_64-unknown-linux-gnu.zip'.freeze
 WASI_VFS_RELEASE_MAC_X86_64 = 'https://github.com/kateinoigakukun/wasi-vfs/releases/download/v0.1.1/wasi-vfs-cli-x86_64-apple-darwin.zip'.freeze
 WASI_VFS_RELEASE_MAC_ARM64 = 'https://github.com/kateinoigakukun/wasi-vfs/releases/download/v0.1.1/wasi-vfs-cli-aarch64-apple-darwin.zip'.freeze
 
-RUBY_ROOT = File.basename(URI(RUBY_RELEASE).path).split('.').first.sub('ruby-', '')
+RUBIES = 'rubies'.freeze
+RUBY_ROOT = 'head-wasm32-unknown-wasi-full-js'.freeze
 WASI_VFS = './wasi-vfs'.freeze
 TMP = 'tmp'.freeze
 DIGEST = 'js/ruby-digest.js'.freeze
 
 namespace :bormashino do
-  desc 'download ruby.wasm and wasi-vfs'
-  task :download do
-    system "curl -L #{RUBY_RELEASE} | tar xz"
-    FileUtils.rm(File.join(RUBY_ROOT, '/usr/local/lib/libruby-static.a'))
-    FileUtils.rm_rf(File.join(RUBY_ROOT, '/usr/local/include'))
-
-    case
-    when OS.linux?
-      system "curl -L '#{WASI_VFS_RELEASE}' | gzip -d > wasi-vfs"
-    when OS.mac?
-      if OS.host_cpu == 'x86_64'
-        system "curl -L -o wasi-vfs.zip '#{WASI_VFS_RELEASE_MAC_X86_64}'"
-      else
-        system "curl -L -o wasi-vfs.zip '#{WASI_VFS_RELEASE_MAC_ARM64}'"
+  desc 'download ruby.wasm'
+  task :download_rubywasm do
+    FileUtils.mkdir_p(RUBIES)
+    Dir.chdir(RUBIES) do
+      unless File.exist?(RELEASE_DATE)
+        FileUtils.mkdir_p(RELEASE_DATE)
+        Dir.chdir(RELEASE_DATE) do
+          system "curl -L #{RUBY_RELEASE} | tar xz"
+          FileUtils.rm(File.join(RUBY_ROOT, '/usr/local/lib/libruby-static.a'))
+          FileUtils.rm_rf(File.join(RUBY_ROOT, '/usr/local/include'))
+        end
       end
-      system 'unzip wasi-vfs.zip'
-      system 'rm wasi-vfs.zip'
     end
-
-    system 'chmod u+x wasi-vfs'
   end
+
+  desc 'download wasi-vfs'
+  task :download_wasivfs do
+    unless File.exist?(WASI_VFS)
+      case
+      when OS.linux?
+        system "curl -L '#{WASI_VFS_RELEASE}' | gzip -d > wasi-vfs"
+      when OS.mac?
+        if OS.host_cpu == 'x86_64'
+          system "curl -L -o wasi-vfs.zip '#{WASI_VFS_RELEASE_MAC_X86_64}'"
+        else
+          system "curl -L -o wasi-vfs.zip '#{WASI_VFS_RELEASE_MAC_ARM64}'"
+        end
+        system 'unzip wasi-vfs.zip'
+        system 'rm wasi-vfs.zip'
+      end
+
+      system 'chmod u+x wasi-vfs'
+    end
+  end
+
+  desc 'download ruby.wasm and wasi-vfs'
+  task download: %i[download_wasivfs download_rubywasm]
 
   desc 'embed ruby scripts with wasi-vfs'
   task :pack, [:additional_args] do |_, args|
+    Rake::Task['bormashino:download'].invoke
+
     gem_dir = Gem::Specification.find_by_name('bormashino').gem_dir
 
     FileUtils.mkdir_p('tmp')
     system([
       "#{WASI_VFS} pack",
-      "#{RUBY_ROOT}/usr/local/bin/ruby",
-      "--mapdir /usr::#{RUBY_ROOT}/usr",
+      "#{RUBIES}/#{RELEASE_DATE}/#{RUBY_ROOT}/usr/local/bin/ruby",
+      "--mapdir /usr::#{RUBIES}/#{RELEASE_DATE}/#{RUBY_ROOT}/usr",
       '--mapdir /src::./src',
       "--mapdir /stub::'#{gem_dir}/lib/bormashino/stub'",
       args[:additional_args],

--- a/gem/spec/bormashino/tasks/bormashino_spec.rb
+++ b/gem/spec/bormashino/tasks/bormashino_spec.rb
@@ -31,7 +31,11 @@ RSpec.describe 'bormashino:*', rake: true do
         end
       end
       expect(`./wasi-vfs --version`).to include 'wasi-vfs-cli '
-      expect(`file head-wasm32-unknown-wasi-full-js/usr/local/bin/ruby`).to include 'WebAssembly (wasm) binary module version 0x1 (MVP)' if OS.linux?
+
+      if OS.linux?
+        filetype = `file rubies/#{RELEASE_DATE}/head-wasm32-unknown-wasi-full-js/usr/local/bin/ruby`
+        expect(filetype).to include 'WebAssembly (wasm) binary module version 0x1 (MVP)'
+      end
     end
   end
 end

--- a/test-app/.gitignore
+++ b/test-app/.gitignore
@@ -45,6 +45,7 @@ config/environments/*.local.yml
 /dist
 /.parcel-cache
 /head-wasm32-unknown-wasi-full-js
+/rubies
 /js/ruby-digest.js
 /wasi-vfs
 .vercel

--- a/test-app/.rubocop.yml
+++ b/test-app/.rubocop.yml
@@ -1,12 +1,13 @@
 inherit_gem:
   fablicop:
-    - "config/.base_rubocop.yml"
+    - 'config/.base_rubocop.yml'
 
 AllCops:
   Exclude:
-    - "src/bundle/**/*"
-    - "node_modules/**/*"
-    - "head-wasm32-unknown-wasi-full-js/**/*"
+    - 'src/bundle/**/*'
+    - 'node_modules/**/*'
+    - 'head-wasm32-unknown-wasi-full-js/**/*'
+    - 'rubies/**/*'
 
 RSpec/InstanceVariable:
   Enabled: false

--- a/test-app/README.md
+++ b/test-app/README.md
@@ -22,7 +22,6 @@ in the template dir
 rbenv install 3.2.0-preview1
 gem install foreman
 bundle install
-bundle exec rake bormashino:download
 (cd src && bundle install)
 npm install
 ./bin/dev

--- a/test-app/spec/spec_helper.rb
+++ b/test-app/spec/spec_helper.rb
@@ -7,10 +7,10 @@ require 'rspec/retry'
 
 class JSConsoleLogger
   def puts(log)
-    src = log.strip.sub(/\A.+[ 0-9\.▶◀]+\{/, '{')
+    src = log.strip.sub(/\A.+[ 0-9.▶◀]+\{/, '{')
     src = JSON.parse(src)
-    STDOUT.puts src['params']['args'].map{|a|a['value']} if src['method'] == 'Runtime.consoleAPICalled'
-  rescue
+    $stdout.puts src['params']['args'].map { |a| a['value'] } if src['method'] == 'Runtime.consoleAPICalled'
+  rescue StandardError
     # do nothing
   end
 end


### PR DESCRIPTION
close #42

- rubocop -a
- ruby.wasm及びwasi-vfsが存在しない場合にダウンロードするように
